### PR TITLE
[feature] add classes which map the tables

### DIFF
--- a/initial_data.sql
+++ b/initial_data.sql
@@ -63,3 +63,24 @@ CREATE TABLE items_in_receipt
     CONSTRAINT fk_iir_receipt
         FOREIGN KEY (receipt_id) REFERENCES receipt (id)
 );
+
+INSERT INTO person
+VALUES (1,'bartosz','andrzejewski','2004-05-04 12:00:00');
+
+INSERT INTO category
+VALUES (1,'food','2004-05-04 12:00:00','2004-05-04 13:20:00');
+
+INSERT INTO quantity
+VALUES (1, '50');
+
+INSERT INTO item
+VALUES (1,'apple',1,1);
+
+INSERT INTO cost
+VALUES (1,2.50,'2004-05-04 22:00:00',1);
+
+INSERT INTO receipt
+VALUES (1,1,'2004-05-04 14:00:00',50);
+
+INSERT INTO items_in_receipt
+VALUES (1,1,1,1);

--- a/src/main/java/pl/kedrabartosz/HomeBudget/HomeBudgetApplication.java
+++ b/src/main/java/pl/kedrabartosz/HomeBudget/HomeBudgetApplication.java
@@ -16,12 +16,37 @@ import pl.kedrabartosz.HomeBudget.version1.repository.ListBasedItemRepository;
 import pl.kedrabartosz.HomeBudget.version1.service.ItemService;
 import pl.kedrabartosz.HomeBudget.version1.service.ReceiptService;
 import pl.kedrabartosz.HomeBudget.version1.Category;
+import pl.kedrabartosz.HomeBudget.version2.repositories.*;
 
 @SpringBootApplication
 public class HomeBudgetApplication {
 
 
     public static void main(String[] args) {
+        ConfigurableApplicationContext context = SpringApplication.run(HomeBudgetApplication.class, args);
+        PersonRepository personRepository = context.getBean(PersonRepository.class);
+        System.out.println(personRepository.findAll());
+
+        CategoryRepository categoryRepository = context.getBean(CategoryRepository.class);
+        System.out.println(categoryRepository.findAll());
+
+        CostRepository costRepository = context.getBean(CostRepository.class);
+        System.out.println(costRepository.findAll());
+
+        pl.kedrabartosz.HomeBudget.version2.repositories.ItemRepository itemRepository = context.getBean(pl.kedrabartosz.HomeBudget.version2.repositories.ItemRepository.class);
+        System.out.println(itemRepository.findAll());
+
+        ItemsInReceiptRepository itemsInReceiptRepository = context.getBean(ItemsInReceiptRepository.class);
+        System.out.println(itemsInReceiptRepository.findAll());
+
+        QuantityRepository quantityRepository = context.getBean(QuantityRepository.class);
+        System.out.println(quantityRepository.findAll());
+
+        ReceiptRepository receiptRepository = context.getBean(ReceiptRepository.class);
+        System.out.println(receiptRepository.findAll());
+    }
+
+    private static void versionOne(String[] args) {
         // SpringApplication.run(HomeBudgetApplication.class, args);
         // CostRepository costRepository = new ListBasedRepository();
         //costRepository.addCost();
@@ -51,8 +76,8 @@ public class HomeBudgetApplication {
         Person me = new Person("Bartosz");
 
 
-        Item newItem = itemService.saveItem( "Jewelry", 250.00, Category.builder().build());
-        Item newItem5 = itemService.saveItem( "Car", 4000, Category.builder().build());
+        Item newItem = itemService.saveItem("Jewelry", 250.00, Category.builder().build());
+        Item newItem5 = itemService.saveItem("Car", 4000, Category.builder().build());
 
         if (itemService.doesItemExits("Pencil")) {
             System.out.println(true);
@@ -60,7 +85,7 @@ public class HomeBudgetApplication {
             System.out.println(false);
         }
 
-        Item newItem6 = itemService.saveItem( "Pencil", 5, Category.builder().build());
+        Item newItem6 = itemService.saveItem("Pencil", 5, Category.builder().build());
         if (itemService.doesItemExits("Pencil")) {
             System.out.println(true);
         } else {
@@ -78,7 +103,6 @@ public class HomeBudgetApplication {
         ReceiptService cartService = context.getBean(ReceiptService.class);
 
 
-
         List<Receipt> all = cartService.getShoppingCarts(me);
         System.out.println("Number cart for " + me.getName() + ": " + all.size());
         all.forEach(System.out::println);
@@ -93,8 +117,6 @@ public class HomeBudgetApplication {
         //@Value - Umożliwia wstrzykiwanie wartości (np. z plików konfiguracyjnych) do pól klasy.
         // @Resource pochodzi od javy a @Autowired od springa
         //Autowired wstrzykuje na podstawie typu a Resource na postawie nazwy
-
-
     }
 }
 // dokonczyc to implemetnowac interfejs Food i tez klasy gdzie beda implementowane te rzeczy! (zrobioone)

--- a/src/main/java/pl/kedrabartosz/HomeBudget/HomeBudgetApplication.java
+++ b/src/main/java/pl/kedrabartosz/HomeBudget/HomeBudgetApplication.java
@@ -6,16 +6,6 @@ import java.util.List;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.ConfigurableApplicationContext;
-import pl.kedrabartosz.HomeBudget.version1.Item;
-import pl.kedrabartosz.HomeBudget.version1.Person;
-import pl.kedrabartosz.HomeBudget.version1.Receipt;
-import pl.kedrabartosz.HomeBudget.version1.repository.ItemRepository;
-import pl.kedrabartosz.HomeBudget.version1.repository.ItemRepositoryFactory;
-import pl.kedrabartosz.HomeBudget.version1.repository.FileBasedCategoryRepository;
-import pl.kedrabartosz.HomeBudget.version1.repository.ListBasedItemRepository;
-import pl.kedrabartosz.HomeBudget.version1.service.ItemService;
-import pl.kedrabartosz.HomeBudget.version1.service.ReceiptService;
-import pl.kedrabartosz.HomeBudget.version1.Category;
 import pl.kedrabartosz.HomeBudget.version2.repositories.*;
 
 @SpringBootApplication
@@ -24,6 +14,7 @@ public class HomeBudgetApplication {
 
     public static void main(String[] args) {
         ConfigurableApplicationContext context = SpringApplication.run(HomeBudgetApplication.class, args);
+
         PersonRepository personRepository = context.getBean(PersonRepository.class);
         System.out.println(personRepository.findAll());
 
@@ -33,7 +24,7 @@ public class HomeBudgetApplication {
         CostRepository costRepository = context.getBean(CostRepository.class);
         System.out.println(costRepository.findAll());
 
-        pl.kedrabartosz.HomeBudget.version2.repositories.ItemRepository itemRepository = context.getBean(pl.kedrabartosz.HomeBudget.version2.repositories.ItemRepository.class);
+        ItemRepository itemRepository = context.getBean(pl.kedrabartosz.HomeBudget.version2.repositories.ItemRepository.class);
         System.out.println(itemRepository.findAll());
 
         ItemsInReceiptRepository itemsInReceiptRepository = context.getBean(ItemsInReceiptRepository.class);
@@ -53,13 +44,14 @@ public class HomeBudgetApplication {
         //System.out.println(costRepository.getAll());
 
         // 1. new
-        ItemRepository itemRepository = new ListBasedItemRepository(new ArrayList<>());
+        pl.kedrabartosz.HomeBudget.version1.repository.ItemRepository itemRepository = new pl.kedrabartosz.HomeBudget.version1.repository.ListBasedItemRepository(new ArrayList<>());
 
         // 2. builder
-        ItemRepository itemRepositoryBuilder = ListBasedItemRepository.builder().build();
+        pl.kedrabartosz.HomeBudget.version1.repository.ItemRepository itemRepositoryBuilder = pl.kedrabartosz.HomeBudget.version1.repository.ListBasedItemRepository.builder().build();
 
         // 3. Factory
-        ItemRepository itemRepositoryFactory = ItemRepositoryFactory.createCostRepository();
+
+        pl.kedrabartosz.HomeBudget.version1.repository.ItemRepository itemRepositoryFactory = pl.kedrabartosz.HomeBudget.version1.repository.ItemRepositoryFactory.createCostRepository();
 
 
         // IoC - Inversion of Control, czyli nie my tworzymy obiekty tylko zlecamy to frameworkpwi
@@ -71,13 +63,13 @@ public class HomeBudgetApplication {
         // aby móc korzystać z costServicu nie możemy go robić (new CostService())!!, tylko
         // pozwalamy Springowi to zrobić i my chcemy tylko się dostać do tego beana, co on stworzył,
         // i na nim operować (ale nie sami go tworzyć)
-        ItemService itemService = context.getBean(ItemService.class);
+        pl.kedrabartosz.HomeBudget.version1.service.ItemService itemService = context.getBean(pl.kedrabartosz.HomeBudget.version1.service.ItemService.class);
 
-        Person me = new Person("Bartosz");
+        pl.kedrabartosz.HomeBudget.version1.Person me = new pl.kedrabartosz.HomeBudget.version1.Person("Bartosz");
 
 
-        Item newItem = itemService.saveItem("Jewelry", 250.00, Category.builder().build());
-        Item newItem5 = itemService.saveItem("Car", 4000, Category.builder().build());
+        pl.kedrabartosz.HomeBudget.version1.Item newItem = itemService.saveItem("Jewelry", 250.00, pl.kedrabartosz.HomeBudget.version1.Category.builder().build());
+        pl.kedrabartosz.HomeBudget.version1.Item newItem5 = itemService.saveItem("Car", 4000, pl.kedrabartosz.HomeBudget.version1.Category.builder().build());
 
         if (itemService.doesItemExits("Pencil")) {
             System.out.println(true);
@@ -85,25 +77,25 @@ public class HomeBudgetApplication {
             System.out.println(false);
         }
 
-        Item newItem6 = itemService.saveItem("Pencil", 5, Category.builder().build());
+        pl.kedrabartosz.HomeBudget.version1.Item newItem6 = itemService.saveItem("Pencil", 5, pl.kedrabartosz.HomeBudget.version1.Category.builder().build());
         if (itemService.doesItemExits("Pencil")) {
             System.out.println(true);
         } else {
             System.out.println(false);
         }
 
-        FileBasedCategoryRepository fileBasedCategoryRepository = new FileBasedCategoryRepository();
-        Category buildHome = fileBasedCategoryRepository.save("budowadomu");
-        Category jewelry = fileBasedCategoryRepository.save("jewelery");
+        pl.kedrabartosz.HomeBudget.version1.repository.CategoryRepository fileBasedCategoryRepository = new pl.kedrabartosz.HomeBudget.version1.repository.FileBasedCategoryRepository();
+        pl.kedrabartosz.HomeBudget.version1.Category buildHome = fileBasedCategoryRepository.save("budowadomu");
+        pl.kedrabartosz.HomeBudget.version1.Category jewelry = fileBasedCategoryRepository.save("jewelery");
         System.out.println(buildHome);
         System.out.println(fileBasedCategoryRepository.getAll());
 
         //shopping cart
 
-        ReceiptService cartService = context.getBean(ReceiptService.class);
+        pl.kedrabartosz.HomeBudget.version1.service.ReceiptService cartService = context.getBean(pl.kedrabartosz.HomeBudget.version1.service.ReceiptService.class);
 
 
-        List<Receipt> all = cartService.getShoppingCarts(me);
+        List<pl.kedrabartosz.HomeBudget.version1.Receipt> all = cartService.getShoppingCarts(me);
         System.out.println("Number cart for " + me.getName() + ": " + all.size());
         all.forEach(System.out::println);
 

--- a/src/main/java/pl/kedrabartosz/HomeBudget/HomeBudgetApplication.java
+++ b/src/main/java/pl/kedrabartosz/HomeBudget/HomeBudgetApplication.java
@@ -6,12 +6,16 @@ import java.util.List;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.ConfigurableApplicationContext;
-import pl.kedrabartosz.HomeBudget.repository.ItemRepository;
-import pl.kedrabartosz.HomeBudget.repository.ItemRepositoryFactory;
-import pl.kedrabartosz.HomeBudget.repository.FileBasedCategoryRepository;
-import pl.kedrabartosz.HomeBudget.repository.ListBasedItemRepository;
-import pl.kedrabartosz.HomeBudget.service.ItemService;
-import pl.kedrabartosz.HomeBudget.service.ReceiptService;
+import pl.kedrabartosz.HomeBudget.version1.Item;
+import pl.kedrabartosz.HomeBudget.version1.Person;
+import pl.kedrabartosz.HomeBudget.version1.Receipt;
+import pl.kedrabartosz.HomeBudget.version1.repository.ItemRepository;
+import pl.kedrabartosz.HomeBudget.version1.repository.ItemRepositoryFactory;
+import pl.kedrabartosz.HomeBudget.version1.repository.FileBasedCategoryRepository;
+import pl.kedrabartosz.HomeBudget.version1.repository.ListBasedItemRepository;
+import pl.kedrabartosz.HomeBudget.version1.service.ItemService;
+import pl.kedrabartosz.HomeBudget.version1.service.ReceiptService;
+import pl.kedrabartosz.HomeBudget.version1.Category;
 
 @SpringBootApplication
 public class HomeBudgetApplication {

--- a/src/main/java/pl/kedrabartosz/HomeBudget/version1/Category.java
+++ b/src/main/java/pl/kedrabartosz/HomeBudget/version1/Category.java
@@ -1,4 +1,4 @@
-package pl.kedrabartosz.HomeBudget;
+package pl.kedrabartosz.HomeBudget.version1;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/pl/kedrabartosz/HomeBudget/version1/Item.java
+++ b/src/main/java/pl/kedrabartosz/HomeBudget/version1/Item.java
@@ -1,4 +1,4 @@
-package pl.kedrabartosz.HomeBudget;
+package pl.kedrabartosz.HomeBudget.version1;
 
 public interface Item {
 

--- a/src/main/java/pl/kedrabartosz/HomeBudget/version1/Person.java
+++ b/src/main/java/pl/kedrabartosz/HomeBudget/version1/Person.java
@@ -1,4 +1,4 @@
-package pl.kedrabartosz.HomeBudget;
+package pl.kedrabartosz.HomeBudget.version1;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src/main/java/pl/kedrabartosz/HomeBudget/version1/Receipt.java
+++ b/src/main/java/pl/kedrabartosz/HomeBudget/version1/Receipt.java
@@ -1,4 +1,4 @@
-package pl.kedrabartosz.HomeBudget;
+package pl.kedrabartosz.HomeBudget.version1;
 
 import lombok.Getter;
 import lombok.ToString;

--- a/src/main/java/pl/kedrabartosz/HomeBudget/version1/SimpleItem.java
+++ b/src/main/java/pl/kedrabartosz/HomeBudget/version1/SimpleItem.java
@@ -1,4 +1,4 @@
-package pl.kedrabartosz.HomeBudget;
+package pl.kedrabartosz.HomeBudget.version1;
 
 public class SimpleItem implements Item {
     private String product;

--- a/src/main/java/pl/kedrabartosz/HomeBudget/version1/repository/CategoryRepository.java
+++ b/src/main/java/pl/kedrabartosz/HomeBudget/version1/repository/CategoryRepository.java
@@ -1,9 +1,7 @@
-package pl.kedrabartosz.HomeBudget.repository;
+package pl.kedrabartosz.HomeBudget.version1.repository;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
 import java.util.Optional;
-import pl.kedrabartosz.HomeBudget.Category;
+import pl.kedrabartosz.HomeBudget.version1.Category;
 
 import java.util.List;
 

--- a/src/main/java/pl/kedrabartosz/HomeBudget/version1/repository/FileBasedCategoryRepository.java
+++ b/src/main/java/pl/kedrabartosz/HomeBudget/version1/repository/FileBasedCategoryRepository.java
@@ -1,6 +1,6 @@
-package pl.kedrabartosz.HomeBudget.repository;
+package pl.kedrabartosz.HomeBudget.version1.repository;
 
-import pl.kedrabartosz.HomeBudget.Category;
+import pl.kedrabartosz.HomeBudget.version1.Category;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;

--- a/src/main/java/pl/kedrabartosz/HomeBudget/version1/repository/ItemRepository.java
+++ b/src/main/java/pl/kedrabartosz/HomeBudget/version1/repository/ItemRepository.java
@@ -1,7 +1,7 @@
-package pl.kedrabartosz.HomeBudget.repository;
+package pl.kedrabartosz.HomeBudget.version1.repository;
 
-import pl.kedrabartosz.HomeBudget.Category;
-import pl.kedrabartosz.HomeBudget.Item;
+import pl.kedrabartosz.HomeBudget.version1.Category;
+import pl.kedrabartosz.HomeBudget.version1.Item;
 
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/pl/kedrabartosz/HomeBudget/version1/repository/ItemRepositoryFactory.java
+++ b/src/main/java/pl/kedrabartosz/HomeBudget/version1/repository/ItemRepositoryFactory.java
@@ -1,4 +1,4 @@
-package pl.kedrabartosz.HomeBudget.repository;
+package pl.kedrabartosz.HomeBudget.version1.repository;
 
 import java.util.ArrayList;
 

--- a/src/main/java/pl/kedrabartosz/HomeBudget/version1/repository/ListBasedCategoryRepository.java
+++ b/src/main/java/pl/kedrabartosz/HomeBudget/version1/repository/ListBasedCategoryRepository.java
@@ -1,13 +1,12 @@
-package pl.kedrabartosz.HomeBudget.repository;
+package pl.kedrabartosz.HomeBudget.version1.repository;
 
 import java.util.Optional;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import org.springframework.stereotype.Repository;
-import pl.kedrabartosz.HomeBudget.Category;
+import pl.kedrabartosz.HomeBudget.version1.Category;
 
-import java.io.FileNotFoundException;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/pl/kedrabartosz/HomeBudget/version1/repository/ListBasedItemRepository.java
+++ b/src/main/java/pl/kedrabartosz/HomeBudget/version1/repository/ListBasedItemRepository.java
@@ -1,11 +1,11 @@
-package pl.kedrabartosz.HomeBudget.repository;
+package pl.kedrabartosz.HomeBudget.version1.repository;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import org.springframework.stereotype.Repository;
-import pl.kedrabartosz.HomeBudget.Category;
-import pl.kedrabartosz.HomeBudget.Item;
-import pl.kedrabartosz.HomeBudget.SimpleItem;
+import pl.kedrabartosz.HomeBudget.version1.Category;
+import pl.kedrabartosz.HomeBudget.version1.Item;
+import pl.kedrabartosz.HomeBudget.version1.SimpleItem;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/pl/kedrabartosz/HomeBudget/version1/repository/ListBasedReceiptRepository.java
+++ b/src/main/java/pl/kedrabartosz/HomeBudget/version1/repository/ListBasedReceiptRepository.java
@@ -1,9 +1,9 @@
-package pl.kedrabartosz.HomeBudget.repository;
+package pl.kedrabartosz.HomeBudget.version1.repository;
 
 import lombok.NoArgsConstructor;
 import org.springframework.stereotype.Repository;
-import pl.kedrabartosz.HomeBudget.Person;
-import pl.kedrabartosz.HomeBudget.Receipt;
+import pl.kedrabartosz.HomeBudget.version1.Person;
+import pl.kedrabartosz.HomeBudget.version1.Receipt;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/pl/kedrabartosz/HomeBudget/version1/repository/ReceiptRepository.java
+++ b/src/main/java/pl/kedrabartosz/HomeBudget/version1/repository/ReceiptRepository.java
@@ -1,7 +1,7 @@
-package pl.kedrabartosz.HomeBudget.repository;
+package pl.kedrabartosz.HomeBudget.version1.repository;
 
-import pl.kedrabartosz.HomeBudget.Person;
-import pl.kedrabartosz.HomeBudget.Receipt;
+import pl.kedrabartosz.HomeBudget.version1.Person;
+import pl.kedrabartosz.HomeBudget.version1.Receipt;
 
 import java.util.List;
 

--- a/src/main/java/pl/kedrabartosz/HomeBudget/version1/service/CategoryService.java
+++ b/src/main/java/pl/kedrabartosz/HomeBudget/version1/service/CategoryService.java
@@ -1,11 +1,11 @@
-package pl.kedrabartosz.HomeBudget.service;
+package pl.kedrabartosz.HomeBudget.version1.service;
 
 import java.util.List;
 import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import pl.kedrabartosz.HomeBudget.Category;
-import pl.kedrabartosz.HomeBudget.repository.CategoryRepository;
+import pl.kedrabartosz.HomeBudget.version1.Category;
+import pl.kedrabartosz.HomeBudget.version1.repository.CategoryRepository;
 
 @Service
 //service sie dodaje dla springa! nie jest to koniecznie bez tego tez by smigalo :D!

--- a/src/main/java/pl/kedrabartosz/HomeBudget/version1/service/ItemService.java
+++ b/src/main/java/pl/kedrabartosz/HomeBudget/version1/service/ItemService.java
@@ -1,13 +1,13 @@
-package pl.kedrabartosz.HomeBudget.service;
+package pl.kedrabartosz.HomeBudget.version1.service;
 
 import java.util.List;
 import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import pl.kedrabartosz.HomeBudget.Category;
-import pl.kedrabartosz.HomeBudget.Item;
-import pl.kedrabartosz.HomeBudget.repository.ItemRepository;
+import pl.kedrabartosz.HomeBudget.version1.Category;
+import pl.kedrabartosz.HomeBudget.version1.Item;
+import pl.kedrabartosz.HomeBudget.version1.repository.ItemRepository;
 
 @Service
 public class ItemService {

--- a/src/main/java/pl/kedrabartosz/HomeBudget/version1/service/ListBasedReceiptService.java
+++ b/src/main/java/pl/kedrabartosz/HomeBudget/version1/service/ListBasedReceiptService.java
@@ -1,12 +1,12 @@
-package pl.kedrabartosz.HomeBudget.service;
+package pl.kedrabartosz.HomeBudget.version1.service;
 
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
-import pl.kedrabartosz.HomeBudget.Category;
-import pl.kedrabartosz.HomeBudget.Item;
-import pl.kedrabartosz.HomeBudget.Person;
-import pl.kedrabartosz.HomeBudget.Receipt;
-import pl.kedrabartosz.HomeBudget.repository.ReceiptRepository;
+import pl.kedrabartosz.HomeBudget.version1.Category;
+import pl.kedrabartosz.HomeBudget.version1.Item;
+import pl.kedrabartosz.HomeBudget.version1.Person;
+import pl.kedrabartosz.HomeBudget.version1.Receipt;
+import pl.kedrabartosz.HomeBudget.version1.repository.ReceiptRepository;
 
 import java.time.Instant;
 import java.util.List;

--- a/src/main/java/pl/kedrabartosz/HomeBudget/version1/service/ReceiptService.java
+++ b/src/main/java/pl/kedrabartosz/HomeBudget/version1/service/ReceiptService.java
@@ -1,10 +1,10 @@
-package pl.kedrabartosz.HomeBudget.service;
+package pl.kedrabartosz.HomeBudget.version1.service;
 
 import java.time.Instant;
-import pl.kedrabartosz.HomeBudget.Category;
-import pl.kedrabartosz.HomeBudget.Item;
-import pl.kedrabartosz.HomeBudget.Person;
-import pl.kedrabartosz.HomeBudget.Receipt;
+import pl.kedrabartosz.HomeBudget.version1.Category;
+import pl.kedrabartosz.HomeBudget.version1.Item;
+import pl.kedrabartosz.HomeBudget.version1.Person;
+import pl.kedrabartosz.HomeBudget.version1.Receipt;
 
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/pl/kedrabartosz/HomeBudget/version2/TestClass.java
+++ b/src/main/java/pl/kedrabartosz/HomeBudget/version2/TestClass.java
@@ -1,0 +1,4 @@
+package pl.kedrabartosz.HomeBudget.version2;
+
+public class TestClass {
+}

--- a/src/main/java/pl/kedrabartosz/HomeBudget/version2/entities/CategoryEntity.java
+++ b/src/main/java/pl/kedrabartosz/HomeBudget/version2/entities/CategoryEntity.java
@@ -4,11 +4,9 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import lombok.ToString;
 
 
 import java.time.Instant;
-@ToString
 @Table(name = "category")
 @Entity
 public class CategoryEntity {

--- a/src/main/java/pl/kedrabartosz/HomeBudget/version2/entities/CategoryEntity.java
+++ b/src/main/java/pl/kedrabartosz/HomeBudget/version2/entities/CategoryEntity.java
@@ -7,16 +7,17 @@ import jakarta.persistence.Table;
 
 
 import java.time.Instant;
+
 @Table(name = "category")
 @Entity
 public class CategoryEntity {
-@Id
-@Column(name = "id")
-private Integer id;
-@Column(name = "name")
-private String name;
-@Column(name = "created_at")
-private Instant createdAt;
-@Column(name = "last_updated_at")
-private Instant lastUpdatedAt;
+    @Id
+    @Column(name = "id")
+    private Integer id;
+    @Column(name = "name")
+    private String name;
+    @Column(name = "created_at")
+    private Instant createdAt;
+    @Column(name = "last_updated_at")
+    private Instant lastUpdatedAt;
 }

--- a/src/main/java/pl/kedrabartosz/HomeBudget/version2/entities/CategoryEntity.java
+++ b/src/main/java/pl/kedrabartosz/HomeBudget/version2/entities/CategoryEntity.java
@@ -1,0 +1,24 @@
+package pl.kedrabartosz.HomeBudget.version2.entities;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.ToString;
+
+
+import java.time.Instant;
+@ToString
+@Table(name = "category")
+@Entity
+public class CategoryEntity {
+@Id
+@Column(name = "id")
+private Integer id;
+@Column(name = "name")
+private String name;
+@Column(name = "created_at")
+private Instant createdAt;
+@Column(name = "last_updated_at")
+private Instant lastUpdatedAt;
+}

--- a/src/main/java/pl/kedrabartosz/HomeBudget/version2/entities/CostEntity.java
+++ b/src/main/java/pl/kedrabartosz/HomeBudget/version2/entities/CostEntity.java
@@ -4,10 +4,9 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import lombok.ToString;
 
 import java.time.Instant;
-@ToString
+
 @Table(name = "cost")
 @Entity
 public class CostEntity {
@@ -18,6 +17,4 @@ public class CostEntity {
     private double price;
     @Column(name = "effective_date")
     private Instant effectiveDate;
-    @Column(name = "item_id")
-    private Integer itemId;
 }

--- a/src/main/java/pl/kedrabartosz/HomeBudget/version2/entities/CostEntity.java
+++ b/src/main/java/pl/kedrabartosz/HomeBudget/version2/entities/CostEntity.java
@@ -1,0 +1,23 @@
+package pl.kedrabartosz.HomeBudget.version2.entities;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.ToString;
+
+import java.time.Instant;
+@ToString
+@Table(name = "cost")
+@Entity
+public class CostEntity {
+    @Id
+    @Column(name = "id")
+    private String id;
+    @Column(name = "price")
+    private double price;
+    @Column(name = "effective_date")
+    private Instant effectiveDate;
+    @Column(name = "item_id")
+    private Integer itemId;
+}

--- a/src/main/java/pl/kedrabartosz/HomeBudget/version2/entities/ItemEntity.java
+++ b/src/main/java/pl/kedrabartosz/HomeBudget/version2/entities/ItemEntity.java
@@ -4,9 +4,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import lombok.ToString;
 
-@ToString
 @Table(name = "item")
 @Entity
 public class ItemEntity {
@@ -15,8 +13,4 @@ public class ItemEntity {
     private Integer id;
     @Column(name = "name")
     private String name;
-    @Column(name = "category_id")
-    private Integer categoryId;
-    @Column(name = "quantity_id")
-    private Integer quantityId;
 }

--- a/src/main/java/pl/kedrabartosz/HomeBudget/version2/entities/ItemEntity.java
+++ b/src/main/java/pl/kedrabartosz/HomeBudget/version2/entities/ItemEntity.java
@@ -1,0 +1,22 @@
+package pl.kedrabartosz.HomeBudget.version2.entities;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.ToString;
+
+@ToString
+@Table(name = "item")
+@Entity
+public class ItemEntity {
+    @Id
+    @Column(name = "id")
+    private Integer id;
+    @Column(name = "name")
+    private String name;
+    @Column(name = "category_id")
+    private Integer categoryId;
+    @Column(name = "quantity_id")
+    private Integer quantityId;
+}

--- a/src/main/java/pl/kedrabartosz/HomeBudget/version2/entities/ItemsInReceiptEntity.java
+++ b/src/main/java/pl/kedrabartosz/HomeBudget/version2/entities/ItemsInReceiptEntity.java
@@ -4,19 +4,13 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import lombok.ToString;
 
-@ToString
 @Table(name = "items_in_receipt")
 @Entity
 public class ItemsInReceiptEntity {
     @Id
     @Column(name = "id")
     private String id;
-    @Column(name = "item_id")
-    private Integer itemId;
     @Column(name = "quantity")
     private Integer quantity;
-    @Column(name = "receipt_id")
-    private Integer receiptId;
 }

--- a/src/main/java/pl/kedrabartosz/HomeBudget/version2/entities/ItemsInReceiptEntity.java
+++ b/src/main/java/pl/kedrabartosz/HomeBudget/version2/entities/ItemsInReceiptEntity.java
@@ -1,0 +1,22 @@
+package pl.kedrabartosz.HomeBudget.version2.entities;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.ToString;
+
+@ToString
+@Table(name = "items_in_receipt")
+@Entity
+public class ItemsInReceiptEntity {
+    @Id
+    @Column(name = "id")
+    private String id;
+    @Column(name = "item_id")
+    private Integer itemId;
+    @Column(name = "quantity")
+    private Integer quantity;
+    @Column(name = "receipt_id")
+    private Integer receiptId;
+}

--- a/src/main/java/pl/kedrabartosz/HomeBudget/version2/entities/ItemsInReceiptEntity.java
+++ b/src/main/java/pl/kedrabartosz/HomeBudget/version2/entities/ItemsInReceiptEntity.java
@@ -12,5 +12,5 @@ public class ItemsInReceiptEntity {
     @Column(name = "id")
     private String id;
     @Column(name = "quantity")
-    private Integer quantity;
+    private int quantity;
 }

--- a/src/main/java/pl/kedrabartosz/HomeBudget/version2/entities/PersonEntity.java
+++ b/src/main/java/pl/kedrabartosz/HomeBudget/version2/entities/PersonEntity.java
@@ -4,10 +4,9 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import lombok.ToString;
 
 import java.time.Instant;
-@ToString
+
 @Table(name = "person")
 @Entity
 public class PersonEntity {

--- a/src/main/java/pl/kedrabartosz/HomeBudget/version2/entities/PersonEntity.java
+++ b/src/main/java/pl/kedrabartosz/HomeBudget/version2/entities/PersonEntity.java
@@ -1,0 +1,23 @@
+package pl.kedrabartosz.HomeBudget.version2.entities;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.ToString;
+
+import java.time.Instant;
+@ToString
+@Table(name = "person")
+@Entity
+public class PersonEntity {
+    @Id
+    @Column(name = "id")
+    private Integer id;
+    @Column(name = "first_name")
+    private String firstName;
+    @Column(name = "last_name")
+    private String lastName;
+    @Column(name = "joined_at")
+    private Instant joinedAt;
+}

--- a/src/main/java/pl/kedrabartosz/HomeBudget/version2/entities/QuantityEntity.java
+++ b/src/main/java/pl/kedrabartosz/HomeBudget/version2/entities/QuantityEntity.java
@@ -1,0 +1,18 @@
+package pl.kedrabartosz.HomeBudget.version2.entities;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.ToString;
+
+@ToString
+@Table(name = "quantity")
+@Entity
+public class QuantityEntity {
+    @Id
+    @Column(name = "id")
+    private Integer id;
+    @Column(name = "value")
+    private String value;
+}

--- a/src/main/java/pl/kedrabartosz/HomeBudget/version2/entities/QuantityEntity.java
+++ b/src/main/java/pl/kedrabartosz/HomeBudget/version2/entities/QuantityEntity.java
@@ -4,9 +4,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import lombok.ToString;
 
-@ToString
 @Table(name = "quantity")
 @Entity
 public class QuantityEntity {

--- a/src/main/java/pl/kedrabartosz/HomeBudget/version2/entities/ReceiptEntity.java
+++ b/src/main/java/pl/kedrabartosz/HomeBudget/version2/entities/ReceiptEntity.java
@@ -4,18 +4,16 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import lombok.ToString;
+
 
 import java.time.Instant;
-@ToString
+
 @Table(name = "receipt")
 @Entity
 public class ReceiptEntity {
     @Id
     @Column(name = "id")
     private String id;
-    @Column(name = "person_id")
-    private Integer personId;
     @Column(name = "purchased_at")
     private Instant purchasedAt;
     @Column(name = "total_cost")

--- a/src/main/java/pl/kedrabartosz/HomeBudget/version2/entities/ReceiptEntity.java
+++ b/src/main/java/pl/kedrabartosz/HomeBudget/version2/entities/ReceiptEntity.java
@@ -1,0 +1,23 @@
+package pl.kedrabartosz.HomeBudget.version2.entities;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.ToString;
+
+import java.time.Instant;
+@ToString
+@Table(name = "receipt")
+@Entity
+public class ReceiptEntity {
+    @Id
+    @Column(name = "id")
+    private String id;
+    @Column(name = "person_id")
+    private Integer personId;
+    @Column(name = "purchased_at")
+    private Instant purchasedAt;
+    @Column(name = "total_cost")
+    private double totalCost;
+}

--- a/src/main/java/pl/kedrabartosz/HomeBudget/version2/repositories/CategoryRepository.java
+++ b/src/main/java/pl/kedrabartosz/HomeBudget/version2/repositories/CategoryRepository.java
@@ -1,0 +1,9 @@
+package pl.kedrabartosz.HomeBudget.version2.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import pl.kedrabartosz.HomeBudget.version2.entities.CategoryEntity;
+
+@Repository
+public interface CategoryRepository extends JpaRepository<CategoryEntity, Integer> {
+}

--- a/src/main/java/pl/kedrabartosz/HomeBudget/version2/repositories/CostRepository.java
+++ b/src/main/java/pl/kedrabartosz/HomeBudget/version2/repositories/CostRepository.java
@@ -1,0 +1,9 @@
+package pl.kedrabartosz.HomeBudget.version2.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import pl.kedrabartosz.HomeBudget.version2.entities.CostEntity;
+
+@Repository
+public interface CostRepository extends JpaRepository<CostEntity, Integer> {
+}

--- a/src/main/java/pl/kedrabartosz/HomeBudget/version2/repositories/ItemRepository.java
+++ b/src/main/java/pl/kedrabartosz/HomeBudget/version2/repositories/ItemRepository.java
@@ -1,0 +1,9 @@
+package pl.kedrabartosz.HomeBudget.version2.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import pl.kedrabartosz.HomeBudget.version2.entities.ItemEntity;
+
+@Repository
+public interface ItemRepository extends JpaRepository<ItemEntity, Integer> {
+}

--- a/src/main/java/pl/kedrabartosz/HomeBudget/version2/repositories/ItemsInReceiptRepository.java
+++ b/src/main/java/pl/kedrabartosz/HomeBudget/version2/repositories/ItemsInReceiptRepository.java
@@ -1,0 +1,9 @@
+package pl.kedrabartosz.HomeBudget.version2.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import pl.kedrabartosz.HomeBudget.version2.entities.ItemsInReceiptEntity;
+
+@Repository
+public interface ItemsInReceiptRepository extends JpaRepository<ItemsInReceiptEntity, Integer> {
+}

--- a/src/main/java/pl/kedrabartosz/HomeBudget/version2/repositories/PersonRepository.java
+++ b/src/main/java/pl/kedrabartosz/HomeBudget/version2/repositories/PersonRepository.java
@@ -1,0 +1,10 @@
+package pl.kedrabartosz.HomeBudget.version2.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import pl.kedrabartosz.HomeBudget.version2.entities.PersonEntity;
+
+@Repository
+public interface PersonRepository extends JpaRepository<PersonEntity, Integer> {
+
+}

--- a/src/main/java/pl/kedrabartosz/HomeBudget/version2/repositories/QuantityRepository.java
+++ b/src/main/java/pl/kedrabartosz/HomeBudget/version2/repositories/QuantityRepository.java
@@ -1,0 +1,9 @@
+package pl.kedrabartosz.HomeBudget.version2.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import pl.kedrabartosz.HomeBudget.version2.entities.QuantityEntity;
+
+@Repository
+public interface QuantityRepository extends JpaRepository<QuantityEntity, Integer> {
+}

--- a/src/main/java/pl/kedrabartosz/HomeBudget/version2/repositories/ReceiptRepository.java
+++ b/src/main/java/pl/kedrabartosz/HomeBudget/version2/repositories/ReceiptRepository.java
@@ -1,0 +1,10 @@
+package pl.kedrabartosz.HomeBudget.version2.repositories;
+
+import lombok.ToString;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import pl.kedrabartosz.HomeBudget.version2.entities.ReceiptEntity;
+
+@Repository
+public interface ReceiptRepository extends JpaRepository<ReceiptEntity, Integer> {
+}

--- a/src/main/resources/categories.csv
+++ b/src/main/resources/categories.csv
@@ -31,3 +31,5 @@
 40,jewelery
 41,budowadomu
 42,jewelery
+43,budowadomu
+44,jewelery

--- a/src/test/java/pl/kedrabartosz/HomeBudget/repository/FileBasedCategoryRepositoryTest.java
+++ b/src/test/java/pl/kedrabartosz/HomeBudget/repository/FileBasedCategoryRepositoryTest.java
@@ -1,8 +1,9 @@
 package pl.kedrabartosz.HomeBudget.repository;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import pl.kedrabartosz.HomeBudget.Category;
+import pl.kedrabartosz.HomeBudget.version1.Category;
+import pl.kedrabartosz.HomeBudget.version1.repository.CategoryRepository;
+import pl.kedrabartosz.HomeBudget.version1.repository.FileBasedCategoryRepository;
 
 import java.util.List;
 

--- a/src/test/java/pl/kedrabartosz/HomeBudget/repository/ListBasedItemRepositoryTest.java
+++ b/src/test/java/pl/kedrabartosz/HomeBudget/repository/ListBasedItemRepositoryTest.java
@@ -2,8 +2,9 @@ package pl.kedrabartosz.HomeBudget.repository;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import pl.kedrabartosz.HomeBudget.Category;
-import pl.kedrabartosz.HomeBudget.Item;
+import pl.kedrabartosz.HomeBudget.version1.Category;
+import pl.kedrabartosz.HomeBudget.version1.Item;
+import pl.kedrabartosz.HomeBudget.version1.repository.ListBasedItemRepository;
 
 import java.util.ArrayList;
 

--- a/src/test/java/pl/kedrabartosz/HomeBudget/service/CategoryServiceTest.java
+++ b/src/test/java/pl/kedrabartosz/HomeBudget/service/CategoryServiceTest.java
@@ -5,8 +5,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import pl.kedrabartosz.HomeBudget.Category;
-import pl.kedrabartosz.HomeBudget.repository.CategoryRepository;
+import pl.kedrabartosz.HomeBudget.version1.Category;
+import pl.kedrabartosz.HomeBudget.version1.repository.CategoryRepository;
+import pl.kedrabartosz.HomeBudget.version1.service.CategoryService;
 
 import java.util.List;
 import java.util.Optional;

--- a/src/test/java/pl/kedrabartosz/HomeBudget/service/MyTestCategoryRepository.java
+++ b/src/test/java/pl/kedrabartosz/HomeBudget/service/MyTestCategoryRepository.java
@@ -1,7 +1,7 @@
 package pl.kedrabartosz.HomeBudget.service;
 
-import pl.kedrabartosz.HomeBudget.Category;
-import pl.kedrabartosz.HomeBudget.repository.CategoryRepository;
+import pl.kedrabartosz.HomeBudget.version1.Category;
+import pl.kedrabartosz.HomeBudget.version1.repository.CategoryRepository;
 
 import java.util.List;
 import java.util.Optional;


### PR DESCRIPTION
## 1. Before

The application contained only one entity class representing the simplest database table. The remaining tables that do not include any foreign key constraints were not yet mapped in the code.

## 2. Problem

The lack of entity classes and repositories for these tables made it impossible to interact with their data using Spring Data. Additionally, the `initial_data.sql` file did not include any test data, so the database was empty after starting the Docker container, which made it impossible to test data reading.

## 3. Solution

I created `@Entity` classes for all simple tables (those without foreign key relations). For each of them, I also created the corresponding `JpaRepository` interface. I added one INSERT statement per table to the initial_data.sql file and started a new Docker container with the database. I verified that reading all rows from these tables works as expected.

## 4. Future Steps
	•	Create entity classes and repositories for tables containing foreign key relations

